### PR TITLE
Add sendgrid.net

### DIFF
--- a/bigmailers.txt
+++ b/bigmailers.txt
@@ -14,6 +14,7 @@ mailchimp.com
 microsoft.com
 outlook.com
 paypal.com
+sendgrid.net
 t-mobile.com
 verizon.com
 yahoo.com


### PR DESCRIPTION
Sendgrid sends from multiple mailservers listed in their SPF record. Adding it to the list is beneficial as a lot of big sites use Sendgrid as their mail infrastructure.